### PR TITLE
Add Button Groups to Pure

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,8 +4,11 @@ Pure Change History
 NEXT
 ----
 
+ * Add horizontal button groups: They can be created by wrapping a collection of
+   `.pure-button` elements within a `.pure-button-group` element. ([#126][])
 
 
+[#126](https://github.com/yui/pure/issues/126)
 
 0.2.1 (2013-07-17)
 ------------------

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@ Pure Change History
 NEXT
 ----
 
- * Add horizontal button groups: They can be created by wrapping a collection of
+ * Added horizontal button groups: They can be created by wrapping a collection of
    `.pure-button` elements within a `.pure-button-group` element. ([#126][])
 
 

--- a/src/buttons/css/buttons-core.css
+++ b/src/buttons/css/buttons-core.css
@@ -20,3 +20,23 @@
     padding: 0;
     border: 0;
 }
+
+/* Inherit .pure-g styles */
+.pure-button-group {
+    letter-spacing: -0.31em; /* Webkit: collapse white-space between units */
+    *letter-spacing: normal; /* reset IE < 8 */
+    *word-spacing: -0.43em; /* IE < 8: collapse white-space between units */
+    text-rendering: optimizespeed; /* Webkit: fixes text-rendering: optimizeLegibility */
+}
+
+.opera-only :-o-prefocus,
+.pure-button-group {
+    word-spacing: -0.43em;
+}
+
+.pure-button-group .pure-button {
+    letter-spacing: normal;
+    word-spacing: normal;
+    vertical-align: top;
+    text-rendering: auto;
+}

--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -38,7 +38,8 @@
 }
 .pure-button-active,
 .pure-button:active {
-    box-shadow: 0 0 0 1px rgba(0,0,0, 0.15) inset, 0 0 6px rgba(0,0,0, 0.20) inset;
+    box-shadow: 0 0 10px 1px rgba(0,0,0,.15) inset,0 0 6px rgba(0,0,0,.2) inset;
+    *font-weight: bold; /* since box-shadow wont show in IE < 8, make the font bold instead to denote active. */
 }
 
 .pure-button[disabled],
@@ -73,4 +74,23 @@ a.pure-button-primary,
 a.pure-button-selected {
     background-color: rgb(0, 120, 231);
     color: #fff;
+}
+
+/* Button Groups */
+.pure-button-group .pure-button {
+    margin: 0;
+    border-radius: 0;
+    border-right: 1px solid #111;  /* fallback color for rgba() for IE7/8 */
+    border-right: 1px solid rgba(0, 0, 0, 0.2);
+
+}
+
+.pure-button-group .pure-button:first-child {
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+}
+.pure-button-group .pure-button:last-child {
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-right: none;
 }

--- a/src/buttons/tests/manual/button.html
+++ b/src/buttons/tests/manual/button.html
@@ -108,5 +108,54 @@
         <input type="button" class="pure-button pure-button-primary" value="Input Button">
         <input type="reset" class="pure-button pure-button-primary" value="Reset">
     </p>
+
+    <h2>Button Groups</h2>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <div class="pure-button-group">
+        <input type="submit" class="pure-button pure-button-primary" value="Submit">
+        <input type="button" class="pure-button pure-button-primary" value="Input Button">
+        <input type="reset" class="pure-button pure-button-primary" value="Reset">
+    </div>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <div class="pure-button-group">
+        <a href="#" class="pure-button pure-button-primary" value="Submit">Testing</a>
+        <a href="#" class="pure-button pure-button-primary" value="Input Button">Button</a>
+        <a href="#" class="pure-button pure-button-primary pure-button-active" value="Reset">Groups</a>
+    </div>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+    <div class="pure-button-group">
+        <button class="pure-button">Lorem</button>
+        <button class="pure-button pure-button-active">Ipsum</button>
+        <button class="pure-button">Dolor</button>
+    </div>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
 </body>
 </html>


### PR DESCRIPTION
This PR adds horizontal button groups to pure, thereby fixing https://github.com/yui/pure/issues/126. 
## Why we need button groups

I think button groups are a good way of grouping multiple buttons together to give them some sense of context. This can be useful in a variety of websites. 
## How it works

The button groups are wrapped in an element with the `.pure-button-group` classname. This element inherits the styles from `.pure-g` to collapse the whitespace within it. The `.pure-button` elements within this reset the letter and word-spacing, similar to `.pure-u`. 
## How it looks

![button groups](http://f.cl.ly/items/3P0m330c0p04241l170S/Screen%20Shot%202013-07-23%20at%2011.33.40%20AM.png)
## Test Coverage
- IE7+
- Chrome
- Safari
- FF
- iOS6
- Android 4.0.x. 
