### PR TITLE
Fixed grouped input square corners special case

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -253,6 +253,10 @@ since IE8 won't execute CSS that contains a CSS3 selector.
     top: 1px;
     border-radius: 4px 4px 0 0;
 }
+.pure-form .pure-group input:first-child:last-child {
+    border-radius: 4px;
+    top: 1px;
+}
 .pure-form .pure-group input:last-child {
     top: -2px;
     border-radius: 0 0 4px 4px;

--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -241,7 +241,7 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form .pure-group input {
     display: block;
     padding: 10px;
-    margin: 0;
+    margin: 0 0 -1px;
     border-radius: 0;
     position: relative;
     top: -1px;
@@ -252,14 +252,17 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form .pure-group input:first-child {
     top: 1px;
     border-radius: 4px 4px 0 0;
+    margin: 0;
 }
 .pure-form .pure-group input:first-child:last-child {
-    border-radius: 4px;
     top: 1px;
+    border-radius: 4px;
+    margin: 0;
 }
 .pure-form .pure-group input:last-child {
     top: -2px;
     border-radius: 0 0 4px 4px;
+    margin: 0;
 }
 .pure-form .pure-group button {
     margin: 0.35em 0;

--- a/src/forms/tests/manual/forms.html
+++ b/src/forms/tests/manual/forms.html
@@ -174,7 +174,40 @@
         <fieldset class="pure-group">
             <input type="text" class="pure-input-1-3" placeholder="Another Group">
             <input type="text" class="pure-input-1-3" placeholder="More Stuff">
+            <input type="text" class="pure-input-1-3" placeholder="Even More Stuff">
+            <input type="text" class="pure-input-1-3" placeholder="Last Item">
             <button type="submit" class="pure-button pure-input-1-3">Sign in</button>
+        </fieldset>
+    </form>
+
+
+    <h2>Dynamic Grouped Inputs</h2>
+
+    <form class="pure-form" onsubmit="return false">
+        <script type="text/javascript">
+        function testDynamicGroupAdd() {
+            var g = document.getElementById('test-dynamic-group'),
+                newNode = g.getElementsByTagName("input")[0].cloneNode();
+
+            g.appendChild(newNode);
+        }
+        function testDynamicGroupRemove() {
+            var g = document.getElementById('test-dynamic-group'),
+                nodeCount = g.getElementsByTagName("input").length;
+
+            if (nodeCount > 1) {
+                g.removeChild(g.lastChild);
+            }
+        }
+        </script>
+
+        <fieldset class="pure-group">
+            <button type="submit" class="pure-button" onclick="testDynamicGroupAdd()">Add field</button>
+            <button type="submit" class="pure-button" onclick="testDynamicGroupRemove()">Remove field</button>
+        </fieldset>
+
+        <fieldset class="pure-group" id="test-dynamic-group">
+            <input type="text" class="pure-input-1-3" placeholder="Add or remove fields to test">
         </fieldset>
     </form>
 


### PR DESCRIPTION
When there is only one input in a .pure-group, it had square top corners. Added a :first-child:last-child rule to have round corners as it should.

This is useful when you want grouped input fields, but where the input elements might be dynamically added to the group, so you start with one input, but more are added later.