### PR TITLE
Fieldset grouping etc

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -238,7 +238,8 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form .pure-group fieldset {
     margin-bottom: 10px;
 }
-.pure-form .pure-group input {
+.pure-form .pure-group input,
+.pure-form .pure-group textarea {
     display: block;
     padding: 10px;
     margin: 0;
@@ -246,16 +247,20 @@ since IE8 won't execute CSS that contains a CSS3 selector.
     position: relative;
     top: -1px;
 }
-.pure-form .pure-group input:focus {
+.pure-form .pure-group input:focus,
+.pure-form .pure-group textarea:focus {
     z-index: 2;
 }
-.pure-form .pure-group input:first-child {
-    top: 1px;
-    border-radius: 4px 4px 0 0;
-}
-.pure-form .pure-group input:last-child {
+.pure-form .pure-group input:last-child,
+.pure-form .pure-group textarea:last-child {
     top: -2px;
     border-radius: 0 0 4px 4px;
+}
+.pure-form .pure-group input:first-child,
+.pure-form .pure-group textarea:first-child {
+    top: 1px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
 }
 .pure-form .pure-group button {
     margin: 0.35em 0;


### PR DESCRIPTION
A pure-group fieldset with only one element had its top and top border radius rules overwritten by the input:last-child rules.

Textareas were also overlooked for some rulesets.

I have tested these modifications as best I can in IE7-11, Safari 5.1.7 on windows, Firefox latest stable on windows, and Chrome latest stable on windows and linux.