### PR TITLE
Refactoring form.css in order to remove unnecessary CSS code

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -132,11 +132,6 @@ since IE8 won't execute CSS that contains a CSS3 selector.
 .pure-form textarea:focus:invalid,
 .pure-form select:focus:invalid {
     color: #b94a48;
-    border-color: #ee5f5b;
-}
-.pure-form input:focus:invalid:focus,
-.pure-form textarea:focus:invalid:focus,
-.pure-form select:focus:invalid:focus {
     border-color: #e9322d;
 }
 .pure-form input[type="file"]:focus:invalid:focus,


### PR DESCRIPTION
5 lines of code can be removed from form.css with no side effects.