### PR TITLE
Use Flexbox when browser @supports it unprefixed

### DIFF
--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -39,6 +39,16 @@
     -ms-flex-flow: row wrap;
 }
 
+/*  Firefox as of 28 supports Flexbox (including flex-wrap) unprefixed.
+    Use unprefixed flexbox when possible with inline-blocks/prefixed flexbox as a fallback.
+*/
+@supports(flex-flow: row wrap)  {
+   .pure-g {
+       display: flex;
+       flex-flow: row wrap;
+   }
+}
+
 /* Opera as of 12 on Windows needs word-spacing.
    The ".opera-only" selector is used to prevent actual prefocus styling
    and is not required in markup.


### PR DESCRIPTION
Don't discriminate Firefox 28+ which supports Flexbox unprefixed (including flex-wrap). We can use unprefixed Flexbox as a main layout mechanism (for all modern browsers), prefixed Flexbox implementations as a fallback and inline-blocks as a last resort.
