### PR TITLE
Replace button gradients with a subtle highlight.

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -16,9 +16,9 @@
     border-radius: 2px;
 }
 
-.pure-button-hover .pure-button-highlight,
-.pure-button:hover .pure-button-highlight,
-.pure-button:focus .pure-button-highlight {
+.pure-button-hover,
+.pure-button:hover,
+.pure-button:focus {
     filter: alpha(opacity=90);
     -khtml-opacity: 0.90;
     -moz-opacity: 0.90;

--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -19,12 +19,10 @@
 .pure-button-hover,
 .pure-button:hover,
 .pure-button:focus {
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#1a000000',GradientType=0);
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(transparent), color-stop(40%, rgba(0,0,0, 0.05)), to(rgba(0,0,0, 0.10)));
-    background-image: -webkit-linear-gradient(transparent, rgba(0,0,0, 0.05) 40%, rgba(0,0,0, 0.10));
-    background-image: -moz-linear-gradient(top, rgba(0,0,0, 0.05) 0%, rgba(0,0,0, 0.10));
-    background-image: -o-linear-gradient(transparent, rgba(0,0,0, 0.05) 40%, rgba(0,0,0, 0.10));
-    background-image: linear-gradient(transparent, rgba(0,0,0, 0.05) 40%, rgba(0,0,0, 0.10));
+    filter: alpha(opacity=90);
+    -khtml-opacity: 0.90;
+    -moz-opacity: 0.90;
+    opacity: 0.90;
 }
 .pure-button:focus {
     outline: 0;
@@ -41,7 +39,6 @@
 .pure-button-disabled:active {
     border: none;
     background-image: none;
-    filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
     filter: alpha(opacity=40);
     -khtml-opacity: 0.40;
     -moz-opacity: 0.40;

--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -16,9 +16,9 @@
     border-radius: 2px;
 }
 
-.pure-button-hover,
-.pure-button:hover,
-.pure-button:focus {
+.pure-button-hover .pure-button-highlight,
+.pure-button:hover .pure-button-highlight,
+.pure-button:focus .pure-button-highlight {
     filter: alpha(opacity=90);
     -khtml-opacity: 0.90;
     -moz-opacity: 0.90;


### PR DESCRIPTION
Replaced the button gradient effect with a subtle highlight effect accomplished simply by setting the opacity to 0.90 on hover and focus.

I followed the guidelines for contributing and gave the buttons a run-through on the manual buttons test page.
