### PR TITLE
Update Grunt compress plugin to remove warnings. Closes #416

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-compress": "^0.9.1",
+    "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-csslint": "^0.2.0",


### PR DESCRIPTION
The Grunt's compress plugin appears to use deprecated module - this results in a warning when running `npm install` in project. This PR updates compress plugin to most recent version.
The tests are passed and project Grunt's task `compress:release` correctly generates `release` archive as envisioned (but not yet covered by tests).
```
zipinfo release/0.5.0/pure/0.5.0/
HISTORY.md                       grids-responsive-old-ie-min.css
LICENSE.md                       grids-responsive-old-ie.css    
README.md                        grids-responsive.css           
base-context-min.css             grids-units-min.css            
base-context.css                 grids-units.css                
base-min.css                     grids.css                      
base.css                         menus-core-min.css             
bower.json                       menus-core.css                 
buttons-core-min.css             menus-min.css                  
buttons-core.css                 menus-nr-min.css               
buttons-min.css                  menus-nr.css                   
buttons.css                      menus-paginator-min.css        
forms-min.css                    menus-paginator.css            
forms-nr-min.css                 menus.css                      
forms-nr.css                     pure-min.css                   
forms.css                        pure-nr-min.css                
grids-core-min.css               pure-nr.css                    
grids-core.css                   pure.css                       
grids-min.css                    tables-min.css                 
grids-responsive-min.css         tables.css
```
I've signed Yahoo's CLA with my Github username.
Thanks!