### PR TITLE
Preventing grids distributing verticle space

### DIFF
--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -37,6 +37,11 @@
     /* IE10 uses display: flexbox */
     display: -ms-flexbox;
     -ms-flex-flow: row wrap;
+    
+    /* Prevents distributing space between rows */
+    -ms-align-content: flex-start;
+	-webkit-align-content: flex-start;
+	align-content: flex-start;
 }
 
 /* Opera as of 12 on Windows needs word-spacing.


### PR DESCRIPTION
When there's a grid container of a defined height excess vertical space gets distributed across the rows rather than allowing each row to take up its natural height [see this fiddle](http://jsfiddle.net/ambekpdm/). As grids are used for horizontal positioning it's pretty counter intuitive to come across it affecting vertical distribution. This can be fixed by adding `align-content: flex-start` to the element with the `pure-g` class.

Not sure if this is something best fixed by adding this style in to Pure itself or something to highlight on the site along with the box-sizing notes. But considering it causes significantly different behaviour in browsers without flexbox I'd consider this to be the best place.