### PR TITLE
Make .pure-g a true flex-box in firefox

### DIFF
--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -30,6 +30,7 @@
     NOTE: Firefox (as of 25) does not currently support flex-wrap, so the
     `-moz-` prefix version is omitted.
     */
+    display: flex;
 
     display: -webkit-flex;
     -webkit-flex-flow: row wrap;


### PR DESCRIPTION
I'm not sure why flex-wrap is important, but as I see it. this change has no downsides and huge benefits.