### PR TITLE
Remove duplicate Firefox inner focus border

### DIFF
--- a/src/buttons/css/buttons.css
+++ b/src/buttons/css/buttons.css
@@ -52,12 +52,6 @@
     display: none;
 }
 
-/* Firefox: Get rid of the inner focus border */
-.pure-button::-moz-focus-inner{
-    padding: 0;
-    border: 0;
-}
-
 .pure-button-primary,
 .pure-button-selected,
 a.pure-button-primary,


### PR DESCRIPTION
Snippet already exists in https://github.com/yahoo/pure/blob/master/src/buttons/css/buttons-core.css#L20

```
  &::-moz-focus-inner {
    padding: 0;
    border: 0;
  }
```
