### PR TITLE
Remove forms box-shadow and border-radius

### DIFF
--- a/src/forms/css/forms.css
+++ b/src/forms/css/forms.css
@@ -25,8 +25,6 @@ so we can ignore the csslint warning.
     padding: 0.5em 0.6em;
     display: inline-block;
     border: 1px solid #ccc;
-    box-shadow: inset 0 1px 3px #ddd;
-    border-radius: 4px;
     vertical-align: middle;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -41,8 +39,6 @@ since IE8 won't execute CSS that contains a CSS3 selector.
     padding: 0.5em 0.6em;
     display: inline-block;
     border: 1px solid #ccc;
-    box-shadow: inset 0 1px 3px #ddd;
-    border-radius: 4px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
Hello,

Pure is awesome but it would be great if it stayed true to it's flatness and minimalism promise and I believe adding shadow and border radius goes against minimalism.

If someone wants shadows or border-radius they can simply add them but to remove them now one needs to use `!important` or add extra classes.