### PR TITLE
Fix for grid inside table in IE 10/11

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Now, all Pure CSS files should be built into the `pure/build/` directory. All
 files that are in this build directory are also available on the CDN. The naming
 conventions of the files in the `build/` directory follow these rules:
 
-* `[module]-core.css`: The minimal set of styles, ususally structural, that
+* `[module]-core.css`: The minimal set of styles, usually structural, that
   provide the base on which the rest of the module's styles build.
 
 * `[module]-nr.css`: Rollup of `[module]-core.css` + `[module].css` +

--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -44,6 +44,13 @@
 	align-content: flex-start;
 }
 
+/* IE10 display: -ms-flexbox (and display: flex in IE 11) does not work inside a table; fall back to block and rely on font hack */
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+	table .pure-g {
+		display: block;
+	}
+}
+
 /* Opera as of 12 on Windows needs word-spacing.
    The ".opera-only" selector is used to prevent actual prefocus styling
    and is not required in markup.

--- a/src/grids/tests/manual/responsive.html
+++ b/src/grids/tests/manual/responsive.html
@@ -446,5 +446,21 @@
         </div>
     </div>
 
+	<h2>Grid Inside Table</h2>
+	<table>
+		<tr>
+			<td>
+				<div class="pure-g">
+					<div class="pure-u-1-2">
+						<div class="content">1/2 Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Vivamus pharetra eros et mattis venenatis.</div>
+					</div>
+					<div class="pure-u-1-2">
+						<div class="content">1/2 Nam neque sapien, lacinia non lectus non, accumsan suscipit ipsum.</div>
+					</div>
+				</div>
+			</td>
+		</tr>
+	</table>
+
 </body>
 </html>


### PR DESCRIPTION
In IE 10 / 11, a grid inside a table does not display (wrap) correctly.

I added an example to the manual test. Load this in IE 10 / 11 (and make the browser small enough so that wrapping is required). IE 10 / 11 doesn't wrap correctly (it works fine outside a table).

The fix uses media query hack to only target IE 10 / 11, and set back to display: block (if inside a table) and rely on the font hack.

I tested in conjunction with pull request #351 to add display: flex for browsers that support it. Note that IE 11 does support display: flex, but has the same issue when inside a table, so also needs the override.

I also tested MS Edge (Spartan), and it renders correctly in the first place; the beta I am using also ignored the -ms media queries and so continued to use flexbox. Interestingly the beta ignored all -ms prefixes but used -webkit prefixes (i.e. with #351 it uses flexbox because of -webkit, not because of -ms).
