### PR TITLE
Change vertical align position inside .pure-u

### DIFF
--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -59,7 +59,7 @@
     zoom: 1;
     letter-spacing: normal;
     word-spacing: normal;
-    vertical-align: top;
+    vertical-align: bottom;
     text-rendering: auto;
 }
 


### PR DESCRIPTION
When there's a `<label>` inside a `.pure-u*` that doesn't fit and ocasionally break a word, this can prevent that our labels and inputs be vertically desaligned making them aligned by the bottom of the input.
