### PR TITLE
Fixing initial copyright year

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,7 +171,7 @@ grunt.initConfig({
                 banner: [
                     '/*!',
                     'Pure v<%= pkg.version %>',
-                    'Copyright 2014 Yahoo! Inc. All rights reserved.',
+                    'Copyright 2013 Yahoo! Inc. All rights reserved.',
                     'Licensed under the BSD License.',
                     'https://github.com/yahoo/pure/blob/master/LICENSE.md',
                     '*/\n'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement (BSD License)
 ========================================
 
-Copyright 2014 Yahoo! Inc. All rights reserved.
+Copyright 2013 Yahoo! Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright