### PR TITLE
Added unprefixed values for autoprefixer or postcss to work

### DIFF
--- a/src/grids/css/grids-core.css
+++ b/src/grids/css/grids-core.css
@@ -37,6 +37,8 @@
     /* IE10 uses display: flexbox */
     display: -ms-flexbox;
     -ms-flex-flow: row wrap;
+    flex-flow: row wrap;
+    display: flex;
     
     /* Prevents distributing space between rows */
     -ms-align-content: flex-start;


### PR DESCRIPTION
We faced an issue while working with [autoprefixer](https://github.com/postcss/autoprefixer) as it can't subtract the unprefixe value from the prefixed one, so FF gets broken. Unprefixed values should persist in any case.
