### PR TITLE
Responsive text alignment for different screen sizes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,8 @@ grunt.initConfig({
             files: [
                 {'build/base.css': [
                     'bower_components/normalize-css/normalize.css',
-                    'build/base.css'
+                    'build/base.css',
+                    'build/align.css'
                 ]},
 
                 {'build/buttons.css': [

--- a/src/base/css/align.css
+++ b/src/base/css/align.css
@@ -1,0 +1,114 @@
+/**
+ * Responsive text alignment for different screen sizes.
+ *
+ * @author Noor Dawod, noor@fineswap.com
+ * @since May 28th, 2016
+ */
+
+.pure-a-initial {
+    text-align: initial;
+}
+
+.pure-a-justify {
+    text-align: justify;
+}
+
+.pure-a-center {
+    text-align: center;
+}
+
+.pure-a-left {
+    text-align: left;
+}
+
+.pure-a-right {
+    text-align: right;
+}
+
+@media screen and (min-width: 35.5em) {
+  .pure-a-sm-initial {
+      text-align: initial;
+  }
+
+  .pure-a-sm-justify {
+      text-align: justify;
+  }
+
+  .pure-a-sm-center {
+      text-align: center;
+  }
+
+  .pure-a-sm-start {
+      text-align: left;
+  }
+
+  .pure-a-sm-end {
+      text-align: right;
+  }
+}
+
+@media screen and (min-width: 48em) {
+    .pure-a-md-initial {
+        text-align: initial;
+    }
+
+    .pure-a-md-justify {
+        text-align: justify;
+    }
+
+    .pure-a-md-center {
+        text-align: center;
+    }
+
+    .pure-a-md-start {
+        text-align: left;
+    }
+
+    .pure-a-md-end {
+        text-align: right;
+    }
+}
+
+@media screen and (min-width: 64em) {
+    .pure-a-lg-initial {
+        text-align: initial;
+    }
+
+    .pure-a-lg-justify {
+        text-align: justify;
+    }
+
+    .pure-a-lg-center {
+        text-align: center;
+    }
+
+    .pure-a-lg-start {
+        text-align: left;
+    }
+
+    .pure-a-lg-end {
+        text-align: right;
+    }
+}
+
+@media screen and (min-width: 80em) {
+    .pure-a-xl-initial {
+        text-align: initial;
+    }
+
+    .pure-a-xl-justify {
+        text-align: justify;
+    }
+
+    .pure-a-xl-center {
+        text-align: center;
+    }
+
+    .pure-a-xl-start {
+        text-align: left;
+    }
+
+    .pure-a-xl-end {
+        text-align: right;
+    }
+}

--- a/src/base/css/align.css
+++ b/src/base/css/align.css
@@ -1,3 +1,5 @@
+/*csslint known-properties:false*/
+
 /**
  * Responsive text alignment for different screen sizes.
  *
@@ -7,6 +9,10 @@
 
 .pure-a-initial {
     text-align: initial;
+}
+
+.pure-a-inherit {
+    text-align: inherit;
 }
 
 .pure-a-justify {
@@ -26,30 +32,38 @@
 }
 
 @media screen and (min-width: 35.5em) {
-  .pure-a-sm-initial {
-      text-align: initial;
-  }
+    .pure-a-sm-initial {
+        text-align: initial;
+    }
 
-  .pure-a-sm-justify {
-      text-align: justify;
-  }
+    .pure-a-sm-inherit {
+        text-align: inherit;
+    }
 
-  .pure-a-sm-center {
-      text-align: center;
-  }
+    .pure-a-sm-justify {
+        text-align: justify;
+    }
 
-  .pure-a-sm-start {
-      text-align: left;
-  }
+    .pure-a-sm-center {
+        text-align: center;
+    }
 
-  .pure-a-sm-end {
-      text-align: right;
-  }
+    .pure-a-sm-start {
+        text-align: left;
+    }
+
+    .pure-a-sm-end {
+        text-align: right;
+    }
 }
 
 @media screen and (min-width: 48em) {
     .pure-a-md-initial {
         text-align: initial;
+    }
+
+    .pure-a-md-inherit {
+        text-align: inherit;
     }
 
     .pure-a-md-justify {
@@ -74,6 +88,10 @@
         text-align: initial;
     }
 
+    .pure-a-lg-inherit {
+        text-align: inherit;
+    }
+
     .pure-a-lg-justify {
         text-align: justify;
     }
@@ -94,6 +112,10 @@
 @media screen and (min-width: 80em) {
     .pure-a-xl-initial {
         text-align: initial;
+    }
+
+    .pure-a-xl-inherit {
+        text-align: inherit;
     }
 
     .pure-a-xl-justify {


### PR DESCRIPTION
Usage is straightforward, much like the grids system:

Use `pure-a-center` to center text for all screens,
Use `pure-a-md-left` to left-align text for medium-sized screens and up.

This is a great addition to an already splendid bare-bones library.
