### PR TITLE
Revert "Remove moot `version` property from bower.json"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "pure",
   "description": "Use Pure's ridiculously tiny CSS to start any web project.",
+  "version": "0.6.1-pre",
   "main": "build/pure.css",
   "devDependencies": {
     "normalize-css": "^3.0"


### PR DESCRIPTION
Reverts yahoo/pure#503

It turns out this version is used by the pure-site repository on the site itself. Adding this back to break the docs site.

@ericf 