### PR TITLE
Add proper module api for node users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,19 @@
+var fs = require('fs');
+var path = require('path');
+var cache = {};
+
+module.exports = {
+    getFile: function(name) {
+        if (!cache[name]) {
+            try {
+                cache[name] = fs.readFileSync(this.getFilePath(name), 'utf-8');
+            } catch(e) {
+                throw new Error(name + ' does not exist');
+            }
+        }
+        return cache[name];
+    },
+    getFilePath: function(name) {
+        return path.resolve(__dirname, 'build', name);
+    }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "url": "git://github.com/yahoo/pure.git"
   },
   "scripts": {
-    "test": "grunt test",
+    "pretest": "grunt build",
+    "test": "grunt test && tap test/*.js",
     "prepublish": "grunt release"
   },
   "files": "build/",
@@ -25,14 +26,16 @@
     "grunt-css-selectors": "^1.1.0",
     "grunt-postcss": "^0.8.0",
     "grunt-pure-grids": "^1.0.0",
-    "grunt-stripmq": "0.0.6"
+    "grunt-stripmq": "0.0.6",
+    "tap": "^8.0.1"
   },
   "description": "Pure is a ridiculously tiny CSS library you can use to start any web project.",
   "bugs": {
     "url": "https://github.com/yahoo/pure/issues"
   },
   "homepage": "http://purecss.io",
-  "main": "build/pure-min.css",
+  "main": "index.js",
+  "browser": "build/pure-min.css",
   "keywords": [
     "pure",
     "css",

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,11 @@
+var tap = require('tap');
+var pure = require('../index.js');
+
+// api
+tap.ok(pure.getFile);
+tap.ok(pure.getFilePath);
+
+// assertions
+tap.match(pure.getFile('pure-min.css'), /pure\-button/, 'should load the file');
+tap.match(pure.getFilePath('pure-min.css'), /pure\-min\.css/, 'should return file path');
+tap.throws(pure.getFile, new Error('undefined does not exist'));


### PR DESCRIPTION
@bugeats @ericf 

Fixes #565

This add a simple API to get the path to a css file and also its contents. 

One caveat here is that I changed `main` from exporting the `build/pure-min.css` to exporting `index.js`. Its technically a breaking change, but the previous behavior would fail because node cannot require a css file. I added the `browser` property back to the original file in case someone is bundling this package for the client. 