### PR TITLE
Fix for postcss-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "http://purecss.io",
   "main": "index.js",
   "browser": "build/pure-min.css",
+  "style": "build/pure.css",
   "keywords": [
     "pure",
     "css",


### PR DESCRIPTION
If the "main" option is not a .css file, then it will look at the "style" option. Adding this value will allow purecss to be imported with postcss-import.